### PR TITLE
fix(navbar): brand title redirects to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,7 +524,7 @@
 <body>
   <header class="topnav" role="banner">
     <div class="topnav-inner">
-      <a class="brand" href="/" title="Home"><span class="logo-blob" aria-hidden="true"></span><span class="brand-text">Hacktoberfest 2025</span></a>
+      <a class="brand" href="./" title="Home"><span class="logo-blob" aria-hidden="true"></span><span class="brand-text">Hacktoberfest 2025</span></a>
 
       <nav class="nav-links" aria-label="Main navigation">
         <a href="#what-is-hacktoberfest">Overview</a>
@@ -544,7 +544,7 @@
   <div class="site">
     <aside class="sidebar" id="sidebar" aria-label="Table of contents">
       <div class="brand">
-        <a href="/" title="Home"><span class="logo-blob" aria-hidden="true"></span>Hacktoberfest 2025</a>
+        <a href="./" title="Home"><span class="logo-blob" aria-hidden="true"></span>Hacktoberfest 2025</a>
       </div>
 
       <div class="search-wrapper">


### PR DESCRIPTION
This PR fixes the issue where clicking the navbar brand/title redirected to a 404 error page on GitHub Pages.

Changes made:

Updated all href="/" brand links to href="./".

Ensures that the brand/title now correctly redirects to the project’s home page when deployed under a subpath (e.g. username.github.io/repo/).

No UI, styling, or layout changes were made.

Testing:

Verified locally using python3 -m http.server.

Brand/title links now redirect to the correct home page instead of error page.

Closes #6 

https://github.com/user-attachments/assets/926b2b28-ea46-4fc9-8fa3-c63c04688f5a

