### PR TITLE
Added theme toggle button with light/dark mode switching. issue #31

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -12,6 +12,22 @@
   --bg-dark: #071126;
 }
 
+/* Light theme variables */
+:root.light-theme {
+  --bg: #ffffff;
+  --card: #ffffff;
+  --muted: #1f2937;
+  --accent: #2563eb;
+  --accent-2: #3b82f6;
+  --glass: rgba(0,0,0,0.05);
+  --bg-dark: #f9fafb;
+}
+
+/* Smooth transitions for theme changes */
+body, .site, .sidebar, .content, .content-inner, .topnav, .nav-links a, .toc-item a, .search-wrapper input {
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
 *{box-sizing:border-box}
 html,body,#content{height:100%;}
 body{
@@ -77,6 +93,35 @@ body{
     padding: 0;
     display: flex;
     align-items: center;
+}
+
+/* Theme toggle button styles */
+#theme-toggle {
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: #fff;
+    font-size: 1.2rem;
+    cursor: pointer;
+    padding: 8px 12px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    transition: all 0.3s ease;
+}
+
+#theme-toggle:hover {
+    background: rgba(255, 255, 255, 0.2);
+    transform: scale(1.05);
+}
+
+.light-theme #theme-toggle {
+    background: rgba(0, 0, 0, 0.1);
+    border-color: rgba(0, 0, 0, 0.2);
+    color: #333;
+}
+
+.light-theme #theme-toggle:hover {
+    background: rgba(0, 0, 0, 0.15);
 }
 .nav-cta {
     background: #021025;
@@ -195,3 +240,163 @@ mark{background:linear-gradient(90deg, rgba(125,211,252,0.16), rgba(96,165,250,0
 .content-inner:hover{box-shadow:0 18px 60px rgba(2,6,23,0.7); transform:translateY(-2px)}
 
 .error-panel{background:linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01)); padding:18px; border-radius:12px; color:var(--muted)}
+
+/* Light theme adjustments */
+.light-theme body {
+  background: #ffffff;
+  color: #111827;
+}
+
+.light-theme .sidebar {
+  background: #ffffff;
+  border-right: 1px solid rgba(0,0,0,0.15);
+}
+
+.light-theme .content-inner {
+  background: #ffffff;
+  box-shadow: 0 10px 40px rgba(0,0,0,0.08);
+}
+
+.light-theme .content-inner:hover {
+  box-shadow: 0 18px 60px rgba(0,0,0,0.12);
+}
+
+.light-theme .search-wrapper input {
+  background: #f9fafb;
+  border: 2px solid rgba(0,0,0,0.15);
+  color: #111827;
+}
+
+.light-theme .search-wrapper input::placeholder {
+  color: #6b7280;
+}
+
+.light-theme .search-wrapper input:focus {
+  background: #ffffff;
+  border-color: #8b5cf6;
+  box-shadow: 0 0 25px rgba(139, 92, 246, 0.15);
+}
+
+.light-theme .search-ico {
+  color: #6b7280;
+}
+
+.light-theme .search-wrapper input:focus + .search-ico {
+  color: #ff6a00;
+}
+
+.light-theme .toc-item a {
+  color: #1f2937;
+}
+
+.light-theme .toc-item a:hover {
+  background: rgba(37,99,235,0.1);
+  color: var(--accent);
+}
+
+.light-theme .nav-links a {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.light-theme pre {
+  background: #1e293b;
+  color: #e2e8f0;
+}
+
+.light-theme #article p {
+  color: #374151;
+}
+
+.light-theme #article h1,
+.light-theme #article h2,
+.light-theme #article h3 {
+  color: #111827;
+}
+
+.light-theme #article h1 {
+  background: linear-gradient(90deg, #ff6a00, #8b5cf6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.light-theme #article h3 {
+  color: #ff6a00;
+}
+
+.light-theme #article ul,
+.light-theme #article ol {
+  color: #1f2937;
+}
+
+.light-theme #article li {
+  color: #374151;
+}
+
+.light-theme #article code {
+  background: rgba(139, 92, 246, 0.1);
+  color: #6b21a8;
+}
+
+.light-theme #article th {
+  background: rgba(139, 92, 246, 0.15);
+  color: #111827;
+}
+
+.light-theme #article td {
+  color: #374151;
+  background: rgba(0,0,0,0.02);
+  border: 1px solid rgba(0,0,0,0.1);
+}
+
+.light-theme #article th {
+  border: 1px solid rgba(0,0,0,0.15);
+}
+
+.light-theme #article a {
+  color: #2563eb;
+}
+
+.light-theme #article a:hover {
+  color: #1d4ed8;
+}
+
+.light-theme .brand a {
+  color: #2563eb;
+}
+
+.light-theme .toc-empty {
+  color: #6b7280;
+}
+
+.light-theme .error-panel {
+  background: #f9fafb;
+  color: #374151;
+  border: 1px solid rgba(0,0,0,0.1);
+}
+
+.light-theme mark {
+  background: linear-gradient(120deg, rgba(255, 106, 0, 0.2), rgba(139, 92, 246, 0.2));
+  color: #111827;
+}
+
+.light-theme .search-highlight {
+  background: linear-gradient(120deg, rgba(255, 106, 0, 0.15), rgba(139, 92, 246, 0.15));
+  color: #111827;
+}
+
+.light-theme #article {
+  color: #1f2937;
+}
+
+.light-theme #article blockquote {
+  border-left: 4px solid #ff6a00;
+  background: rgba(255, 106, 0, 0.05);
+  color: #374151;
+}
+
+.light-theme #article strong,
+.light-theme #article b {
+  color: #111827;
+}
+

--- a/index.html
+++ b/index.html
@@ -534,6 +534,9 @@
       </nav>
 
       <div class="nav-actions">
+        <button id="theme-toggle" class="nav-btn" title="Toggle theme" aria-label="Toggle light/dark theme">
+          <span class="theme-icon">🌙</span>
+        </button>
         <button id="nav-search-btn" class="nav-btn" title="Search (/)" aria-label="Open search">🔎</button>
         <a class="nav-cta" href="https://github.com/avinash201199/Hacktoberfest2025" target="_blank" rel="noopener">GitHub</a>
         <button id="hamburger" class="nav-btn" aria-label="Toggle sidebar">☰</button>
@@ -757,6 +760,32 @@
       const expanded = sidebar.classList.toggle('collapsed');
       e.target.textContent = expanded ? 'Show' : 'Hide';
       e.target.setAttribute('aria-expanded', String(!expanded));
+    });
+
+    // Theme Toggle Functionality
+    const themeToggle = document.getElementById('theme-toggle');
+    const themeIcon = themeToggle.querySelector('.theme-icon');
+    const htmlElement = document.documentElement;
+    
+    // Check for saved theme preference or default to dark mode
+    const currentTheme = localStorage.getItem('theme') || 'dark';
+    if (currentTheme === 'light') {
+      htmlElement.classList.add('light-theme');
+      themeIcon.textContent = '☀️';
+    }
+    
+    // Theme toggle click handler
+    themeToggle.addEventListener('click', () => {
+      htmlElement.classList.toggle('light-theme');
+      
+      // Update icon and save preference
+      if (htmlElement.classList.contains('light-theme')) {
+        themeIcon.textContent = '☀️';
+        localStorage.setItem('theme', 'light');
+      } else {
+        themeIcon.textContent = '🌙';
+        localStorage.setItem('theme', 'dark');
+      }
     });
 
     // Navbar interactions: focus search and toggle sidebar


### PR DESCRIPTION
fixed issue #31 

Theme Toggle Button in Navbar 🌙☀️

Added a beautiful theme toggle button in the navigation bar
Button displays moon icon (🌙) for dark mode and sun icon (☀️) for light mode
Positioned next to the search button
Light/Dark Mode Switching

Dark Mode: Original dark theme with gradient backgrounds
Light Mode: Clean white background with dark text (#111827)
Theme preference is saved in localStorage and persists across page reloads
Smooth Transitions ✨

Added CSS transitions (0.3s ease) for all theme-related properties
Smooth color changes for:
Background colors
Text colors
Border colors
All interactive elements

Comprehensive Light Theme Styling

All text is now visible in light mode including:
Headings (h1, h2, h3)
Paragraphs and lists
Table content
Links and navigation
Code blocks
Search input
Sidebar content
Strong/bold text