### PR TITLE
fix(readme): correct badge URL typo in Hacktoberfest badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Join WhatsApp channel for any doubts](https://chat.whatsapp.com/BfBWJhy4xj3CJFSGE2qBrL)
 
-![Hacktoberfest](https://img.shields.io/badge/Hacktoberfest-2025-blueviolet?style=for-the-bhackthebox)  
+![Hacktoberfest](https://img.shields.io/badge/Hacktoberfest-2025-blueviolet?style=for-the-badge)  
 ![Open Source](https://img.shields.io/badge/Open--Source-💻-success?style=for-the-badge)  
 ![Contributions Welcome](https://img.shields.io/badge/Contributions-Welcome-brightgreen?style=for-the-badge&logo=github)
 


### PR DESCRIPTION
## Description
Fixes #82 

Fixed a typo in the Hacktoberfest badge URL where "bhackthebox" was incorrectly used instead of "badge".

## Changes Made
- Fixed typo in README.md: `style=for-the-bhackthebox` → `style=for-the-badge`

## Testing
- [x] Verified the badge displays correctly
- [x] No other changes made to the file