### PR TITLE
fix: restore focus styling by defining CSS variables

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,11 @@
         --spacing-sm: 0.5rem;
         --spacing-md: 1rem;
         --spacing-lg: 2rem;
+        --accent-orange: var(--hf-orange);
+        --accent-purple: var(--hf-purple);
+        --on-accent: var(--hf-light);
+        --radius-pill: 999px;
+        --soft-shadow: 0 4px 15px rgba(155, 89, 182, 0.3);
       }
 
       .logo-blob {


### PR DESCRIPTION
## Summary
Restores focus outlines and gradient button styling in [index.html](cci:7://file:///d:/Hacktoberfest2025/index.html:0:0-0:0) by defining the missing custom properties (`--accent-orange`, `--accent-purple`, `--on-accent`, `--radius-pill`, `--soft-shadow`) within the inline `:root` block.

## Related Issue
Resolves: N/A

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the repository style
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] I have read the contributing guidelines

## How to test
- Open [index.html](cci:7://file:///d:/Hacktoberfest2025/index.html:0:0-0:0) in a browser.
- Tab through navigation/sidebar controls to confirm focus outlines use the brand colors.
- Inspect themed buttons like `#toc-toggle` and `.nav-cta`; verify gradients render correctly.

## Screenshots (if applicable)
N/A

## Additional notes
None.