### PR TITLE
Add TRUST-SCAN- to beginner-friendly list

### DIFF
--- a/BeginnersFriendlyRepositories.md
+++ b/BeginnersFriendlyRepositories.md
@@ -28,7 +28,7 @@ If you know any good repository for beginners, feel free to add it to this table
 | OpenSauce | [Link](https://github.com/TechnoBlogger14o3/OpenSauce) | Multiple Languages, DSA, Algorithms |
 | Awesome Lists | [Link](https://github.com/sindresorhus/awesome) | Markdown, Documentation |
 | 30 Seconds of Code | [Link](https://github.com/30-seconds/30-seconds-of-code) | JavaScript, TypeScript, Python |
-
+| TRUST-SCAN- | [link](https://github.com/Madhur-K4/TRUST-SCAN-) | Java,SQL,springboot |
 
 
 ---


### PR DESCRIPTION

I've added my beginner-friendly repository to the list for Hacktoberfest 2025.

TRUST-SCAN-
URL: https://github.com/Madhur-K4/TRUST-SCAN-
Tech Stack: Java, sql,springboot

This repository and is suitable for beginner contributors during Hacktoberfest.

Checklist
 I've added my repository to the beginners-friendly list
 My repository has open issues for contributors
 I've followed the existing table format